### PR TITLE
Interpret use statements

### DIFF
--- a/src/FileParser.php
+++ b/src/FileParser.php
@@ -8,7 +8,7 @@ class FileParser extends BaseParser {
     TokenQueue $tq,
   ) {
     try {
-      $this->defs = (new ScopeConsumer($tq, ScopeType::FILE_SCOPE))
+      $this->defs = (new ScopeConsumer($tq, ScopeType::FILE_SCOPE, Map{}))
         ->getBuilder()
         ->setPosition(shape('filename' => $file))
         ->build();

--- a/src/consumers/ClassConsumer.php
+++ b/src/consumers/ClassConsumer.php
@@ -69,9 +69,9 @@ final class ClassConsumer extends Consumer {
 
       if ($ttype === T_IMPLEMENTS) {
         invariant(
-           $this->type !== ClassDefinitionType::INTERFACE_DEF,
-           'interfaces can not implement interfaces at line %d',
-           $this->tq->getLine(),
+          $this->type !== ClassDefinitionType::INTERFACE_DEF,
+          'interfaces can not implement interfaces at line %d',
+          $this->tq->getLine(),
         );
         $builder->setInterfaces($this->consumeClassList());
       }
@@ -98,7 +98,8 @@ final class ClassConsumer extends Consumer {
         break;
       }
 
-      $classes[] = (new TypehintConsumer($this->tq, $this->aliases))->getTypehint();
+      $classes[] = (new TypehintConsumer($this->tq, $this->aliases))
+        ->getTypehint();
     }
     return $classes;
   }

--- a/src/consumers/ClassConsumer.php
+++ b/src/consumers/ClassConsumer.php
@@ -12,8 +12,9 @@ final class ClassConsumer extends Consumer {
   public function __construct(
     private ClassDefinitionType $type,
     TokenQueue $tq,
+    \ConstMap<string, string> $aliases,
   ) {
-    parent::__construct($tq);
+    parent::__construct($tq, $aliases);
   }
 
   public function getBuilder(): ScannedClassBuilder {
@@ -41,7 +42,7 @@ final class ClassConsumer extends Consumer {
     list($_, $ttype) = $this->tq->peek();
     if ($ttype == T_TYPELIST_LT) {
       $builder->setGenericTypes(
-        (new GenericsConsumer($this->tq))->getGenerics(),
+        (new GenericsConsumer($this->tq, $this->aliases))->getGenerics(),
       );
     }
 
@@ -78,7 +79,7 @@ final class ClassConsumer extends Consumer {
 
     return $builder
       ->setContents(
-        (new ScopeConsumer($this->tq, ScopeType::CLASS_SCOPE))
+        (new ScopeConsumer($this->tq, ScopeType::CLASS_SCOPE, $this->aliases))
         ->getBuilder()
       );
   }
@@ -97,7 +98,7 @@ final class ClassConsumer extends Consumer {
         break;
       }
 
-      $classes[] = (new TypehintConsumer($this->tq))->getTypehint();
+      $classes[] = (new TypehintConsumer($this->tq, $this->aliases))->getTypehint();
     }
     return $classes;
   }

--- a/src/consumers/ConstantConsumer.php
+++ b/src/consumers/ConstantConsumer.php
@@ -26,7 +26,7 @@ final class ConstantConsumer extends Consumer {
         list($_, $nnt) = $this->tq->peek();
         if ($nnt === T_STRING) {
           $this->tq->unshift($next, $next_type);
-          $typehint = (new TypehintConsumer($this->tq))->getTypehint();
+          $typehint = (new TypehintConsumer($this->tq, $this->aliases))->getTypehint();
           continue;
         } else {
           $name = $next;

--- a/src/consumers/ConstantConsumer.php
+++ b/src/consumers/ConstantConsumer.php
@@ -26,7 +26,8 @@ final class ConstantConsumer extends Consumer {
         list($_, $nnt) = $this->tq->peek();
         if ($nnt === T_STRING) {
           $this->tq->unshift($next, $next_type);
-          $typehint = (new TypehintConsumer($this->tq, $this->aliases))->getTypehint();
+          $typehint = (new TypehintConsumer($this->tq, $this->aliases))
+            ->getTypehint();
           continue;
         } else {
           $name = $next;

--- a/src/consumers/Consumer.php
+++ b/src/consumers/Consumer.php
@@ -66,7 +66,7 @@ abstract class Consumer {
 
   protected function unaliasName(?string $name): ?string {
 
-    if($name === null) {
+    if ($name === null) {
       return $name;
     }
 
@@ -74,7 +74,7 @@ abstract class Consumer {
     $base = $parts[0];
     $realBase = $this->aliases->get($base);
 
-    if($realBase === null) {
+    if ($realBase === null) {
       return $name;
     }
 

--- a/src/consumers/Consumer.php
+++ b/src/consumers/Consumer.php
@@ -5,6 +5,7 @@ namespace FredEmmott\DefinitionFinder;
 abstract class Consumer {
   public function __construct(
     protected TokenQueue $tq,
+    protected \ConstMap<string, string> $aliases
   ) {
   }
 
@@ -61,5 +62,23 @@ abstract class Consumer {
         }
       }
     }
+  }
+
+  protected function unaliasName(?string $name): ?string {
+
+    if($name === null) {
+      return $name;
+    }
+
+    $parts = explode('\\', $name);
+    $base = $parts[0];
+    $realBase = $this->aliases->get($base);
+
+    if($realBase === null) {
+      return $name;
+    }
+
+    $parts[0] = $realBase;
+    return implode('\\', $parts);
   }
 }

--- a/src/consumers/FunctionAbstractConsumer.php
+++ b/src/consumers/FunctionAbstractConsumer.php
@@ -44,11 +44,11 @@ abstract class FunctionAbstractConsumer<T as ScannedFunctionAbstract>
 
     $builder = static::ConstructBuilder($name)
       ->setByRefReturn($by_ref_return);
- 
+
     list($_, $ttype) = $tq->peek();
     $generics = Vector { };
     if ($ttype === T_TYPELIST_LT) {
-      $generics = (new GenericsConsumer($tq))->getGenerics();
+      $generics = (new GenericsConsumer($tq, $this->aliases))->getGenerics();
     }
     $builder->setGenerics($generics);
     $this->consumeParameterList($builder);
@@ -58,7 +58,7 @@ abstract class FunctionAbstractConsumer<T as ScannedFunctionAbstract>
     if ($t === ':') {
       $tq->shift();
       $this->consumeWhitespace();
-      $builder->setReturnType((new TypehintConsumer($this->tq))->getTypehint());
+      $builder->setReturnType((new TypehintConsumer($this->tq, $this->aliases))->getTypehint());
     }
     return $builder;
   }
@@ -110,7 +110,7 @@ abstract class FunctionAbstractConsumer<T as ScannedFunctionAbstract>
         $default = $this->consumeDefaultValue();
         $name = substr($t, 1); // remove '$'
         invariant(
-          $variadic || !$have_variadic,  
+          $variadic || !$have_variadic,
           'non-variadic parameter after variadic at line %d',
           $tq->getLine(),
         );
@@ -149,7 +149,7 @@ abstract class FunctionAbstractConsumer<T as ScannedFunctionAbstract>
       }
 
       if ($ttype === T_SL) {
-        $attrs = (new UserAttributesConsumer($this->tq))->getUserAttributes();
+        $attrs = (new UserAttributesConsumer($this->tq, $this->aliases))->getUserAttributes();
         continue;
       }
 
@@ -157,7 +157,7 @@ abstract class FunctionAbstractConsumer<T as ScannedFunctionAbstract>
         $doc = $t;
         continue;
       }
-      
+
       invariant(
         $param_type === null,
         'found two things that look like typehints for the same parameter '.
@@ -165,7 +165,7 @@ abstract class FunctionAbstractConsumer<T as ScannedFunctionAbstract>
         $tq->getLine(),
       );
       $tq->unshift($t, $ttype);
-      $param_type = (new TypehintConsumer($this->tq))->getTypehint();
+      $param_type = (new TypehintConsumer($this->tq, $this->aliases))->getTypehint();
     }
   }
 

--- a/src/consumers/FunctionAbstractConsumer.php
+++ b/src/consumers/FunctionAbstractConsumer.php
@@ -58,7 +58,8 @@ abstract class FunctionAbstractConsumer<T as ScannedFunctionAbstract>
     if ($t === ':') {
       $tq->shift();
       $this->consumeWhitespace();
-      $builder->setReturnType((new TypehintConsumer($this->tq, $this->aliases))->getTypehint());
+      $builder->setReturnType((new TypehintConsumer($this->tq, $this->aliases))
+        ->getTypehint());
     }
     return $builder;
   }
@@ -149,7 +150,8 @@ abstract class FunctionAbstractConsumer<T as ScannedFunctionAbstract>
       }
 
       if ($ttype === T_SL) {
-        $attrs = (new UserAttributesConsumer($this->tq, $this->aliases))->getUserAttributes();
+        $attrs = (new UserAttributesConsumer($this->tq, $this->aliases))
+          ->getUserAttributes();
         continue;
       }
 
@@ -165,7 +167,8 @@ abstract class FunctionAbstractConsumer<T as ScannedFunctionAbstract>
         $tq->getLine(),
       );
       $tq->unshift($t, $ttype);
-      $param_type = (new TypehintConsumer($this->tq, $this->aliases))->getTypehint();
+      $param_type = (new TypehintConsumer($this->tq, $this->aliases))
+        ->getTypehint();
     }
   }
 

--- a/src/consumers/GenericsConsumer.php
+++ b/src/consumers/GenericsConsumer.php
@@ -33,7 +33,7 @@ class GenericsConsumer extends Consumer {
         if ($name !== null) {
           $ret[] = new ScannedGeneric(
             $name,
-            $constraint,
+            $this->unaliasName($constraint),
             $variance,
             $relationship,
           );
@@ -49,7 +49,7 @@ class GenericsConsumer extends Consumer {
       if ($t === ',') {
         $ret[] = new ScannedGeneric(
           nullthrows($name),
-          $constraint,
+          $this->unaliasName($constraint),
           $variance,
           $relationship,
         );

--- a/src/consumers/NamespaceConsumer.php
+++ b/src/consumers/NamespaceConsumer.php
@@ -27,7 +27,7 @@ class NamespaceConsumer extends Consumer {
 
     $builder = (new ScannedNamespaceBuilder($ns))
       ->setContents(
-        (new ScopeConsumer($this->tq, ScopeType::NAMESPACE_SCOPE))
+        (new ScopeConsumer($this->tq, ScopeType::NAMESPACE_SCOPE, Map{}))
           ->getBuilder()
     );
     return $builder;

--- a/src/consumers/ScopeConsumer.php
+++ b/src/consumers/ScopeConsumer.php
@@ -59,7 +59,8 @@ class ScopeConsumer extends Consumer {
       }
 
       if ($ttype === T_SL && $scope_depth === 1 && $parens_depth === 0) {
-        $attrs = (new UserAttributesConsumer($tq, $this->scopeAliases))->getUserAttributes();
+        $attrs = (new UserAttributesConsumer($tq, $this->scopeAliases))
+          ->getUserAttributes();
         continue;
       }
 
@@ -84,10 +85,11 @@ class ScopeConsumer extends Consumer {
 
       // I hate you, PHP.
       if ($ttype === T_STRING && strtolower($token) === 'define') {
-        $sub_builder = (new DefineConsumer($tq, $this->scopeAliases))->getBuilder();
+        $sub_builder = (new DefineConsumer($tq, $this->scopeAliases))
+          ->getBuilder();
         // I hate you more, PHP. $sub_builder is null in case we've not
         // actually got a constant: define($variable, ...);
-        if ($sub_builder ) {
+        if ($sub_builder) {
           $builder->addConstant($sub_builder);
         }
         continue;
@@ -114,7 +116,8 @@ class ScopeConsumer extends Consumer {
 
       if ($ttype === T_STRING) {
         $tq->unshift($token, $ttype);
-        $property_type = (new TypehintConsumer($tq, $this->scopeAliases))->getTypehint();
+        $property_type = (new TypehintConsumer($tq, $this->scopeAliases))
+          ->getTypehint();
         continue;
       }
 
@@ -175,13 +178,19 @@ class ScopeConsumer extends Consumer {
 
     switch ($def_type) {
       case DefinitionType::NAMESPACE_DEF:
-        $builder->addNamespace((new NamespaceConsumer($this->tq, $this->scopeAliases))->getBuilder());
+        $builder->addNamespace(
+          (new NamespaceConsumer($this->tq, $this->scopeAliases))->getBuilder()
+        );
         return;
       case DefinitionType::CLASS_DEF:
       case DefinitionType::INTERFACE_DEF:
       case DefinitionType::TRAIT_DEF:
         $builder->addClass(
-          (new ClassConsumer(ClassDefinitionType::assert($def_type), $this->tq, $this->scopeAliases))
+          (new ClassConsumer(
+            ClassDefinitionType::assert($def_type),
+            $this->tq,
+            $this->scopeAliases
+          ))
             ->getBuilder()
             ->setAttributes($attrs)
             ->setDocComment($docblock)
@@ -189,9 +198,11 @@ class ScopeConsumer extends Consumer {
         return;
       case DefinitionType::FUNCTION_DEF:
         if ($this->scopeType === ScopeType::CLASS_SCOPE) {
-          $fb = (new MethodConsumer($this->tq, $this->scopeAliases))->getBuilder();
+          $fb = (new MethodConsumer($this->tq, $this->scopeAliases))
+            ->getBuilder();
         } else {
-          $fb = (new FunctionConsumer($this->tq, $this->scopeAliases))->getBuilder();
+          $fb = (new FunctionConsumer($this->tq, $this->scopeAliases))
+            ->getBuilder();
         }
 
         if (!$fb) {

--- a/src/consumers/ScopeConsumer.php
+++ b/src/consumers/ScopeConsumer.php
@@ -9,11 +9,16 @@ enum ScopeType: string {
 }
 
 class ScopeConsumer extends Consumer {
+
+  private Map<string, string> $scopeAliases;
+
   public function __construct(
     TokenQueue $tq,
     private ScopeType $scopeType,
+    \ConstMap<string, string> $aliases,
   ) {
-    parent::__construct($tq);
+    $this->scopeAliases = new Map($aliases);
+    parent::__construct($tq, $aliases);
   }
 
   public function getBuilder(): ScannedScopeBuilder {
@@ -54,7 +59,7 @@ class ScopeConsumer extends Consumer {
       }
 
       if ($ttype === T_SL && $scope_depth === 1 && $parens_depth === 0) {
-        $attrs = (new UserAttributesConsumer($tq))->getUserAttributes();
+        $attrs = (new UserAttributesConsumer($tq, $this->scopeAliases))->getUserAttributes();
         continue;
       }
 
@@ -72,9 +77,14 @@ class ScopeConsumer extends Consumer {
         continue;
       }
 
+      if ($ttype === T_USE && $this->scopeType !== ScopeType::CLASS_SCOPE) {
+        $this->scopeAliases->add($this->consumeUseStatement());
+        continue;
+      }
+
       // I hate you, PHP.
       if ($ttype === T_STRING && strtolower($token) === 'define') {
-        $sub_builder = (new DefineConsumer($tq))->getBuilder();
+        $sub_builder = (new DefineConsumer($tq, $this->scopeAliases))->getBuilder();
         // I hate you more, PHP. $sub_builder is null in case we've not
         // actually got a constant: define($variable, ...);
         if ($sub_builder ) {
@@ -104,7 +114,7 @@ class ScopeConsumer extends Consumer {
 
       if ($ttype === T_STRING) {
         $tq->unshift($token, $ttype);
-        $property_type = (new TypehintConsumer($tq))->getTypehint();
+        $property_type = (new TypehintConsumer($tq, $this->scopeAliases))->getTypehint();
         continue;
       }
 
@@ -165,13 +175,13 @@ class ScopeConsumer extends Consumer {
 
     switch ($def_type) {
       case DefinitionType::NAMESPACE_DEF:
-        $builder->addNamespace((new NamespaceConsumer($this->tq))->getBuilder());
+        $builder->addNamespace((new NamespaceConsumer($this->tq, $this->scopeAliases))->getBuilder());
         return;
       case DefinitionType::CLASS_DEF:
       case DefinitionType::INTERFACE_DEF:
       case DefinitionType::TRAIT_DEF:
         $builder->addClass(
-          (new ClassConsumer(ClassDefinitionType::assert($def_type), $this->tq))
+          (new ClassConsumer(ClassDefinitionType::assert($def_type), $this->tq, $this->scopeAliases))
             ->getBuilder()
             ->setAttributes($attrs)
             ->setDocComment($docblock)
@@ -179,9 +189,9 @@ class ScopeConsumer extends Consumer {
         return;
       case DefinitionType::FUNCTION_DEF:
         if ($this->scopeType === ScopeType::CLASS_SCOPE) {
-          $fb = (new MethodConsumer($this->tq))->getBuilder();
+          $fb = (new MethodConsumer($this->tq, $this->scopeAliases))->getBuilder();
         } else {
-          $fb = (new FunctionConsumer($this->tq))->getBuilder();
+          $fb = (new FunctionConsumer($this->tq, $this->scopeAliases))->getBuilder();
         }
 
         if (!$fb) {
@@ -211,7 +221,7 @@ class ScopeConsumer extends Consumer {
         return;
       case DefinitionType::CONST_DEF:
         $builder->addConstant(
-          (new ConstantConsumer($this->tq))
+          (new ConstantConsumer($this->tq, $this->scopeAliases))
           ->getBuilder()
           ->setDocComment($docblock)
         );
@@ -268,5 +278,75 @@ class ScopeConsumer extends Consumer {
     do {
       list ($_, $ttype) = $this->tq->shift();
     } while ($this->tq->haveTokens() && $ttype !== T_OPEN_TAG);
+  }
+
+  private function consumeUseStatement(): Pair<string, string> {
+    $parts = [];
+    $alias = '';
+
+    do {
+      $this->consumeWhitespace();
+      list($name, $type) = $this->tq->shift();
+
+      if ($type === T_STRING) {
+        $parts[] = $name;
+        continue;
+
+      } else if ($type === T_NS_SEPARATOR) {
+        continue;
+
+      } else if ($type === T_AS) {
+        $alias = $this->consumeAlias();
+        break;
+
+      } else if ($name === ';') {
+        break;
+      }
+
+      invariant_violation(
+        'Unexpected token %s',
+        var_export($name, true),
+      );
+
+    } while ($this->tq->haveTokens());
+
+    if($alias === '') {
+       $alias = $parts[count($parts) - 1];
+    }
+
+    $namespace = implode('\\', $parts);
+
+    return Pair{$alias, $namespace};
+  }
+
+  private function consumeAlias(): string {
+
+    $this->consumeWhitespace();
+
+    if($this->tq->isEmpty()) {
+      invariant_violation('Expected alias name after AS statement.');
+    }
+
+    list($name, $type) = $this->tq->shift();
+    if($type !== T_STRING) {
+      invariant_violation(
+        'Unexpected token %s',
+        var_export($name, true),
+      );
+    }
+
+    $this->consumeWhitespace();
+
+    if(!$this->tq->isEmpty()) {
+       list($next, $_) = $this->tq->shift();
+       if($next !== ';') {
+         invariant_violation(
+           'Unexpected token %s',
+           var_export($next, true),
+         );
+       }
+    }
+
+    return $name;
   }
 }

--- a/src/consumers/TypehintConsumer.php
+++ b/src/consumers/TypehintConsumer.php
@@ -144,6 +144,7 @@ final class TypehintConsumer extends Consumer {
       }
       break;
     }
+    $type = $this->unaliasName($type);
     invariant($type !== null, 'expected a type');
     return new ScannedTypehint($type, $generics, $nullable);
   }

--- a/tests/AbstractHackTest.php
+++ b/tests/AbstractHackTest.php
@@ -1,7 +1,9 @@
 <?hh // strict
 
+use FredEmmott\DefinitionFinder\ScannedClass;
 use FredEmmott\DefinitionFinder\ScannedFunction;
-use FredEmmott\DefinitionFinder\ScannedTypehint;
+use FredEmmott\DefinitionFinder\ScannedFunctionAbstract;
+use FredEmmott\DefinitionFinder\ScannedMethod;
 
 abstract class AbstractHackTest extends PHPUnit_Framework_TestCase {
   private ?FredEmmott\DefinitionFinder\FileParser $parser;
@@ -20,6 +22,7 @@ abstract class AbstractHackTest extends PHPUnit_Framework_TestCase {
       Vector {
         $this->getPrefix().'SimpleClass',
         $this->getPrefix().'GenericClass',
+        $this->getPrefix().'GenericAliasedConstraintClass',
         $this->getPrefix().'AbstractFinalClass',
         $this->getPrefix().'AbstractClass',
         $this->getPrefix().'xhp_foo',
@@ -71,6 +74,11 @@ abstract class AbstractHackTest extends PHPUnit_Framework_TestCase {
         $this->getPrefix().'returns_int',
         $this->getPrefix().'returns_generic',
         $this->getPrefix().'returns_nested_generic',
+        $this->getPrefix().'aliased',
+        $this->getPrefix().'aliased_with_namespace',
+        $this->getPrefix().'aliased_with_nested_namespace',
+        $this->getPrefix().'aliased_namespace',
+        $this->getPrefix().'aliased_no_as',
       },
       $this->parser?->getFunctionNames(),
     );
@@ -101,6 +109,19 @@ abstract class AbstractHackTest extends PHPUnit_Framework_TestCase {
 
     $this->assertEquals(
       Vector {null, null},
+      $class->getGenericTypes()->map($x ==> $x->getConstraintTypeName()),
+    );
+
+    $class = $this->parser?->getClass($this->getPrefix().'GenericAliasedConstraintClass');
+    assert($class !== null);
+
+    $this->assertEquals(
+      Vector {'T'},
+      $class->getGenericTypes()->map($x ==> $x->getName()),
+    );
+
+    $this->assertEquals(
+      Vector {'Foo'},
       $class->getGenericTypes()->map($x ==> $x->getConstraintTypeName()),
     );
   }
@@ -157,9 +178,42 @@ abstract class AbstractHackTest extends PHPUnit_Framework_TestCase {
     $this->assertEmpty($sub_sub_type?->getGenericTypes());
   }
 
+  public function testAliasedTypehints(): void {
+    $data = Map {
+      'Foo' => $this->getFunction('aliased'),
+      'SingleNamespace\Foo' => $this->getFunction('aliased_with_namespace'),
+      'Namespaces\AreNested\Now\Foo' => $this->getFunction('aliased_with_nested_namespace'),
+      'Namespaces\AreNested\Now\Foo' => $this->getFunction('aliased_namespace'),
+      'Namespaces\AreNested\Now\Bar' => $this->getFunction('aliased_no_as'),
+      'Namespaces\AreNested\Now\Bar' => $this->getClassMethod('SimpleClass', 'aliasInClassScope'),
+    };
+    foreach($data as $typeName => $fun) {
+      $returnType = $fun->getReturnType();
+      $paramType = $fun->getParameters()->get(0)?->getTypehint();
+      $this->assertSame($typeName, $returnType?->getTypeName());
+      $this->assertSame($typeName, $paramType?->getTypeName());
+    }
+  }
+
   private function getFunction(string $name): ScannedFunction {
     $func = $this->parser?->getFunction($this->getPrefix().$name);
     invariant($func !== null, 'Could not find function %s', $name);
     return $func;
+  }
+
+  private function getClass(string $name): ScannedClass {
+    $class = $this->parser?->getClass($this->getPrefix().$name);
+    invariant($class !== null, 'Could not find class %s', $name);
+    return $class;
+  }
+
+  private function getClassMethod(string $className, string $methodName): ScannedMethod {
+    $method = $this
+      ->getClass($className)
+      ->getMethods()
+      ->filter($m ==> $m->getName() === $methodName)
+      ->get(0);
+    invariant($method !== null, 'Could not find method %s in class %s', $methodName, $className);
+    return $method;
   }
 }

--- a/tests/AbstractHackTest.php
+++ b/tests/AbstractHackTest.php
@@ -112,7 +112,9 @@ abstract class AbstractHackTest extends PHPUnit_Framework_TestCase {
       $class->getGenericTypes()->map($x ==> $x->getConstraintTypeName()),
     );
 
-    $class = $this->parser?->getClass($this->getPrefix().'GenericAliasedConstraintClass');
+    $class = $this->parser?->getClass(
+      $this->getPrefix().'GenericAliasedConstraintClass'
+    );
     assert($class !== null);
 
     $this->assertEquals(
@@ -181,11 +183,22 @@ abstract class AbstractHackTest extends PHPUnit_Framework_TestCase {
   public function testAliasedTypehints(): void {
     $data = Map {
       'Foo' => $this->getFunction('aliased'),
-      'SingleNamespace\Foo' => $this->getFunction('aliased_with_namespace'),
-      'Namespaces\AreNested\Now\Foo' => $this->getFunction('aliased_with_nested_namespace'),
-      'Namespaces\AreNested\Now\Foo' => $this->getFunction('aliased_namespace'),
-      'Namespaces\AreNested\Now\Bar' => $this->getFunction('aliased_no_as'),
-      'Namespaces\AreNested\Now\Bar' => $this->getClassMethod('SimpleClass', 'aliasInClassScope'),
+        'SingleNamespace\Foo' => $this->getFunction(
+          'aliased_with_namespace'
+        ),
+      'Namespaces\AreNested\Now\Foo' => $this->getFunction(
+        'aliased_with_nested_namespace'
+      ),
+      'Namespaces\AreNested\Now\Foo' => $this->getFunction(
+        'aliased_namespace'
+      ),
+      'Namespaces\AreNested\Now\Bar' => $this->getFunction(
+        'aliased_no_as'
+      ),
+      'Namespaces\AreNested\Now\Bar' => $this->getClassMethod(
+        'SimpleClass',
+        'aliasInClassScope'
+      ),
     };
     foreach($data as $typeName => $fun) {
       $returnType = $fun->getReturnType();
@@ -207,13 +220,21 @@ abstract class AbstractHackTest extends PHPUnit_Framework_TestCase {
     return $class;
   }
 
-  private function getClassMethod(string $className, string $methodName): ScannedMethod {
+  private function getClassMethod(
+    string $className,
+    string $methodName
+  ): ScannedMethod {
     $method = $this
       ->getClass($className)
       ->getMethods()
       ->filter($m ==> $m->getName() === $methodName)
       ->get(0);
-    invariant($method !== null, 'Could not find method %s in class %s', $methodName, $className);
+    invariant(
+      $method !== null,
+      'Could not find method %s in class %s',
+      $methodName,
+      $className
+    );
     return $method;
   }
 }

--- a/tests/data/alias_reference_nested_namespace.php
+++ b/tests/data/alias_reference_nested_namespace.php
@@ -1,0 +1,6 @@
+<?hh
+
+namespace Namespaces\AreNested\Now;
+
+class Foo { }
+class Bar { }

--- a/tests/data/alias_reference_no_namespace.php
+++ b/tests/data/alias_reference_no_namespace.php
@@ -1,0 +1,3 @@
+<?hh
+
+class Foo { }

--- a/tests/data/alias_reference_single_namespace.php
+++ b/tests/data/alias_reference_single_namespace.php
@@ -1,0 +1,5 @@
+<?hh
+
+namespace SingleNamespace;
+
+class Foo { }

--- a/tests/data/nested_namespace_hack.php
+++ b/tests/data/nested_namespace_hack.php
@@ -2,13 +2,25 @@
 
 namespace Namespaces\AreNestedNow;
 
+use Foo as Aliased;
+use SingleNamespace\Foo as AliasedWithNamespace;
+use Namespaces\AreNested\Now\Foo as AliasedWithNestedNamespace;
+use Namespaces\AreNested\Now\Bar;
+use Namespaces\AreNested\Now as AliasedNamespace;
+
 class SimpleClass {
   public function iAmNotAGlobalFunction(): void { }
+  public function aliasInClassScope(Bar $bar): Bar {
+    return $bar;
+  }
 }
 
 class GenericClass<Tk, Tv> {
   const NOT_A_GLOBAL_CONSTANT = 42;
   const int ALSO_NOT_A_GLOBAL_CONSTANT = 42;
+}
+
+class GenericAliasedConstraintClass<T as Aliased> {
 }
 
 abstract final class AbstractFinalClass {
@@ -41,6 +53,26 @@ function returns_generic(): Vector<int> { return Vector { 123 }; }
 
 function returns_nested_generic(): Vector<Vector<int>> {
   return Vector { Vector { 123 } };
+}
+
+function aliased(Aliased $aliased): Aliased {
+  return $aliased;
+}
+
+function aliased_with_namespace(AliasedWithNamespace $aliased): AliasedWithNamespace {
+  return $aliased;
+}
+
+function aliased_with_nested_namespace(AliasedWithNestedNamespace $aliased): AliasedWithNestedNamespace {
+  return $aliased;
+}
+
+function aliased_namespace(AliasedNamespace\Foo $aliased): AliasedNamespace\Foo {
+  return $aliased;
+}
+
+function aliased_no_as(Bar $aliased): Bar {
+   return $aliased;
 }
 
 const MY_CONST = 456;

--- a/tests/data/nested_namespace_hack.php
+++ b/tests/data/nested_namespace_hack.php
@@ -59,15 +59,21 @@ function aliased(Aliased $aliased): Aliased {
   return $aliased;
 }
 
-function aliased_with_namespace(AliasedWithNamespace $aliased): AliasedWithNamespace {
+function aliased_with_namespace(
+  AliasedWithNamespace $aliased,
+): AliasedWithNamespace {
   return $aliased;
 }
 
-function aliased_with_nested_namespace(AliasedWithNestedNamespace $aliased): AliasedWithNestedNamespace {
+function aliased_with_nested_namespace(
+  AliasedWithNestedNamespace $aliased,
+): AliasedWithNestedNamespace {
   return $aliased;
 }
 
-function aliased_namespace(AliasedNamespace\Foo $aliased): AliasedNamespace\Foo {
+function aliased_namespace(
+  AliasedNamespace\Foo $aliased,
+): AliasedNamespace\Foo {
   return $aliased;
 }
 

--- a/tests/data/no_namespace_hack.php
+++ b/tests/data/no_namespace_hack.php
@@ -1,12 +1,24 @@
 <?hh
 
+use Foo as Aliased;
+use SingleNamespace\Foo as AliasedWithNamespace;
+use Namespaces\AreNested\Now\Foo as AliasedWithNestedNamespace;
+use Namespaces\AreNested\Now\Bar;
+use Namespaces\AreNested\Now as AliasedNamespace;
+
 class SimpleClass {
   public function iAmNotAGlobalFunction(): void { }
+  public function aliasInClassScope(Bar $bar): Bar {
+    return $bar;
+  }
 }
 
 class GenericClass<Tk, Tv> {
   const NOT_A_GLOBAL_CONSTANT = 42;
   const int ALSO_NOT_A_GLOBAL_CONSTANT = 42;
+}
+
+class GenericAliasedConstraintClass<T as Aliased> {
 }
 
 abstract final class AbstractFinalClass {
@@ -39,6 +51,26 @@ function returns_generic(): Vector<int> { return Vector { 123 }; }
 
 function returns_nested_generic(): Vector<Vector<int>> {
   return Vector { Vector { 123 } };
+}
+
+function aliased(Aliased $aliased): Aliased {
+  return $aliased;
+}
+
+function aliased_with_namespace(AliasedWithNamespace $aliased): AliasedWithNamespace {
+  return $aliased;
+}
+
+function aliased_with_nested_namespace(AliasedWithNestedNamespace $aliased): AliasedWithNestedNamespace {
+  return $aliased;
+}
+
+function aliased_namespace(AliasedNamespace\Foo $aliased): AliasedNamespace\Foo {
+  return $aliased;
+}
+
+function aliased_no_as(Bar $aliased): Bar {
+   return $aliased;
 }
 
 const MY_CONST = 456;

--- a/tests/data/no_namespace_hack.php
+++ b/tests/data/no_namespace_hack.php
@@ -57,15 +57,21 @@ function aliased(Aliased $aliased): Aliased {
   return $aliased;
 }
 
-function aliased_with_namespace(AliasedWithNamespace $aliased): AliasedWithNamespace {
+function aliased_with_namespace(
+    AliasedWithNamespace $aliased,
+): AliasedWithNamespace {
   return $aliased;
 }
 
-function aliased_with_nested_namespace(AliasedWithNestedNamespace $aliased): AliasedWithNestedNamespace {
+function aliased_with_nested_namespace(
+    AliasedWithNestedNamespace $aliased,
+): AliasedWithNestedNamespace {
   return $aliased;
 }
 
-function aliased_namespace(AliasedNamespace\Foo $aliased): AliasedNamespace\Foo {
+function aliased_namespace(
+    AliasedNamespace\Foo $aliased,
+): AliasedNamespace\Foo {
   return $aliased;
 }
 

--- a/tests/data/single_namespace_hack.php
+++ b/tests/data/single_namespace_hack.php
@@ -59,15 +59,21 @@ function aliased(Aliased $aliased): Aliased {
   return $aliased;
 }
 
-function aliased_with_namespace(AliasedWithNamespace $aliased): AliasedWithNamespace {
+function aliased_with_namespace(
+    AliasedWithNamespace $aliased,
+): AliasedWithNamespace {
   return $aliased;
 }
 
-function aliased_with_nested_namespace(AliasedWithNestedNamespace $aliased): AliasedWithNestedNamespace {
+function aliased_with_nested_namespace(
+    AliasedWithNestedNamespace $aliased,
+): AliasedWithNestedNamespace {
   return $aliased;
 }
 
-function aliased_namespace(AliasedNamespace\Foo $aliased): AliasedNamespace\Foo {
+function aliased_namespace(
+    AliasedNamespace\Foo $aliased,
+): AliasedNamespace\Foo {
   return $aliased;
 }
 

--- a/tests/data/single_namespace_hack.php
+++ b/tests/data/single_namespace_hack.php
@@ -2,13 +2,25 @@
 
 namespace SingleNamespace;
 
+use Foo as Aliased;
+use SingleNamespace\Foo as AliasedWithNamespace;
+use Namespaces\AreNested\Now\Foo as AliasedWithNestedNamespace;
+use Namespaces\AreNested\Now\Bar;
+use Namespaces\AreNested\Now as AliasedNamespace;
+
 class SimpleClass {
   public function iAmNotAGlobalFunction(): void { }
+  public function aliasInClassScope(Bar $bar): Bar {
+    return $bar;
+  }
 }
 
 class GenericClass<Tk, Tv> {
   const NOT_A_GLOBAL_CONSTANT = 42;
   const int ALSO_NOT_A_GLOBAL_CONSTANT = 42;
+}
+
+class GenericAliasedConstraintClass<T as Aliased> {
 }
 
 abstract final class AbstractFinalClass {
@@ -41,6 +53,26 @@ function returns_generic(): Vector<int> { return Vector { 123 }; }
 
 function returns_nested_generic(): Vector<Vector<int>> {
   return Vector { Vector { 123 } };
+}
+
+function aliased(Aliased $aliased): Aliased {
+  return $aliased;
+}
+
+function aliased_with_namespace(AliasedWithNamespace $aliased): AliasedWithNamespace {
+  return $aliased;
+}
+
+function aliased_with_nested_namespace(AliasedWithNestedNamespace $aliased): AliasedWithNestedNamespace {
+  return $aliased;
+}
+
+function aliased_namespace(AliasedNamespace\Foo $aliased): AliasedNamespace\Foo {
+  return $aliased;
+}
+
+function aliased_no_as(Bar $aliased): Bar {
+   return $aliased;
 }
 
 const MY_CONST = 456;


### PR DESCRIPTION
Use the aliases defined with "use Foo\Bar as Baz" to reference the FQN of parameter, return, and generic type hints.

It is a little bit of an overkill to put the `$aliases` Map in the base `Consumer` class, but as far as I can tell, only the `ConstantConsumer`, `DefineConsumer`, and `UserAttributesConsumer` didn't actually need it.

I hope the style is consistent with yours, @fredemmott :) 