### PR TITLE
Perform more whitespace consumption when parsing user attributes.

### DIFF
--- a/src/consumers/UserAttributesConsumer.php
+++ b/src/consumers/UserAttributesConsumer.php
@@ -6,17 +6,20 @@ final class UserAttributesConsumer extends Consumer {
   public function getUserAttributes(): AttributeMap {
     $attrs = Map { };
     while (true) {
+      $this->consumeWhitespace();
+
       list($name, $_) = $this->tq->shift();
       if (!$attrs->containsKey($name)) {
         $attrs[$name] = Vector { };
       }
+
+      $this->consumeWhitespace();
 
       list($t, $ttype) = $this->tq->shift();
       if ($ttype === T_SR) { // this was the last attribute
         return $attrs;
       }
       if ($t === ',') { // there's another
-        $this->consumeWhitespace();
         continue;
       }
 
@@ -34,6 +37,9 @@ final class UserAttributesConsumer extends Consumer {
       // Possibly multiple values
       $attr_value = null;
       while ($this->tq->haveTokens()) {
+
+        $this->consumeWhitespace();
+
         list($value, $ttype) = $this->tq->shift();
         switch ((int) $ttype) {
           case T_CONSTANT_ENCAPSED_STRING:
@@ -75,6 +81,7 @@ final class UserAttributesConsumer extends Consumer {
         $this->consumeWhitespace();
       }
 
+      $this->consumeWhitespace();
       list($t, $ttype) = $this->tq->shift();
       if ($ttype === T_SR) {
         return $attrs;

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -43,6 +43,14 @@ class AttributesTest extends \PHPUnit_Framework_TestCase {
     );
   }
 
+  public function testWithFormattedAttributes(): void {
+    $class = $this->findClass('ClassWithFormattedAttributes');
+    $this->assertEquals(
+      Map { 'Foo' => Vector { }, 'Bar' => Vector {'herp', 'derp'} },
+      $class->getAttributes(),
+    );
+  }
+
   public function testWithSingleIntAttribute(): void {
     $class = $this->findClass('ClassWithIntAttribute');
     $this->assertEquals(
@@ -107,7 +115,7 @@ class AttributesTest extends \PHPUnit_Framework_TestCase {
 
   private function findScanned<T as ScannedBase>(
     \ConstVector<T> $container,
-    string $name, 
+    string $name,
   ): T {
     foreach ($container as $scanned) {
       if ($scanned->getName() === "FredEmmott\\DefinitionFinder\\Test\\".$name) {

--- a/tests/data/attributes.php
+++ b/tests/data/attributes.php
@@ -22,3 +22,13 @@ function function_after_classes(): void {}
 
 <<ClassFoo>>
 class ClassAfterFunction {}
+
+<<
+Foo,
+Bar
+(
+    'herp',
+    'derp'
+)
+>>
+class ClassWithFormattedAttributes {}


### PR DESCRIPTION
This allows complicated user attribute annotations with multiple attribute names and parameter lists.

Just for reference, the type checker allows for these newline. (i.e., the type checker is not giving me errors for the attribute I added in `tests/data/attributes.php`).