### PR TITLE
Property and constant fixes

### DIFF
--- a/src/consumers/ConstantConsumer.php
+++ b/src/consumers/ConstantConsumer.php
@@ -35,6 +35,15 @@ final class ConstantConsumer extends Consumer {
         }
       }
       if ($next === '=') {
+        $this->consumeWhitespace();
+        while ($this->tq->haveTokens()) {
+          list($nnv, $nnt) = $this->tq->shift();
+          if ($nnv === ';') {
+            $this->tq->unshift($nnv, $nnt);
+            break;
+          }
+          $value .= $nnv;
+        }
         $builder = new ScannedConstantBuilder(
           nullthrows($name),
           $value,

--- a/src/consumers/DefineConsumer.php
+++ b/src/consumers/DefineConsumer.php
@@ -41,6 +41,21 @@ final class DefineConsumer extends Consumer {
       );
       $name = substr($name, 1, strlen($name) - 2);
     }
+    $this->consumeWhitespace();
+    list($next, $_) = $tq->shift();
+    invariant(
+      $next === ',',
+      'Expected first define argument to be followed by a comma',
+    );
+    $this->consumeWhitespace();
+    while ($this->tq->haveTokens()) {
+      list($nnv, $nnt) = $this->tq->shift();
+      if ($nnv === ')') {
+        $this->tq->unshift($nnv, $nnt);
+        break;
+      }
+      $value .= $nnv;
+    }
     $this->consumeStatement();
     return new ScannedConstantBuilder(
       $name,

--- a/src/consumers/ScopeConsumer.php
+++ b/src/consumers/ScopeConsumer.php
@@ -121,7 +121,8 @@ class ScopeConsumer extends Consumer {
         continue;
       }
 
-      if ($ttype === T_VARIABLE) {
+      // make sure we're not inside a method body
+      if ($ttype === T_VARIABLE && $scope_depth === 1) {
         $name = substr($token, 1); // remove prefixed '$'
         if ($visibility === null) {
           $visibility = VisibilityToken::T_PUBLIC;

--- a/src/consumers/TypehintConsumer.php
+++ b/src/consumers/TypehintConsumer.php
@@ -89,6 +89,7 @@ final class TypehintConsumer extends Consumer {
         && $ttype !== T_ARRAY
         && $ttype !== T_XHP_LABEL
         && $ttype !== T_DICT
+        && $ttype !== T_VEC
       ) {
         continue;
       }

--- a/src/utils.php
+++ b/src/utils.php
@@ -17,3 +17,5 @@ function normalize_xhp_class(string $in): string {
 // facebook/hhvm#4872
 const int T_TYPELIST_LT = 398;
 const int T_TYPELIST_GT = 399;
+// Defined in runtime in global namespace, but not in HHI
+const int T_VEC = 443;

--- a/tests/AbstractHackTest.php
+++ b/tests/AbstractHackTest.php
@@ -96,6 +96,10 @@ abstract class AbstractHackTest extends PHPUnit_Framework_TestCase {
       },
       $this->parser?->getConstantNames(),
     );
+    $this->assertEquals(
+      Vector { '456', '123', '789', "'herp'", "'derp'" },
+      $this->parser?->getConstants()?->map($x ==> $x->getValue()),
+    );
   }
 
   public function testClassGenerics(): void {

--- a/tests/ClassContentsTest.php
+++ b/tests/ClassContentsTest.php
@@ -79,15 +79,19 @@ class ClassContentsTest extends \PHPUnit_Framework_TestCase {
   public function testHackConstants(): void {
     $constants = $this->class?->getConstants();
     $this->assertEquals(
-      Vector { 'FOO' },
+      Vector { 'FOO', 'BAR' },
       $constants?->map($x ==> $x->getName()),
     );
     $this->assertEquals(
-      Vector { 'string' },
+      Vector { 'string', 'int' },
       $constants?->map($x ==> $x->getTypehint()?->getTypeName()),
     );
     $this->assertEquals(
-      Vector { '/** FooDoc */' },
+      Vector { "'bar'", '60 * 60 * 24' },
+      $constants?->map($x ==> $x->getValue()),
+    );
+    $this->assertEquals(
+      Vector { '/** FooDoc */', '/** BarDoc */' },
       $constants?->map($x ==> $x->getDocComment()),
     );
   }
@@ -98,15 +102,19 @@ class ClassContentsTest extends \PHPUnit_Framework_TestCase {
     $constants = $class->getConstants();
 
     $this->assertEquals(
-      Vector { 'FOO' },
+      Vector { 'FOO', 'BAR' },
       $constants->map($x ==> $x->getName()),
     );
     $this->assertEquals(
-      Vector { null },
+      Vector { null, null },
       $constants->map($x ==> $x->getTypehint()),
     );
     $this->assertEquals(
-      Vector { '/** FooDoc */' },
+      Vector { "'bar'", '60 * 60 * 24' },
+      $constants->map($x ==> $x->getValue()),
+    );
+    $this->assertEquals(
+      Vector { '/** FooDoc */', '/** BarDoc */' },
       $constants->map($x ==> $x->getDocComment()),
     );
   }

--- a/tests/ClassPropertiesTest.php
+++ b/tests/ClassPropertiesTest.php
@@ -1,0 +1,94 @@
+<?hh // strict
+
+namespace FredEmmott\DefinitionFinder\Test;
+
+use FredEmmott\DefinitionFinder\FileParser;
+use FredEmmott\DefinitionFinder\ScannedClass;
+
+class ClassPropertiesTest extends \PHPUnit_Framework_TestCase {
+  private ?\ConstVector<ScannedClass> $classes;
+
+  protected function setUp(): void {
+    $parser = FileParser::FromFile(
+      __DIR__.'/data/class_properties.php'
+    );
+    $this->classes = $parser->getClasses();
+  }
+
+  public function testPropertyNames(): void {
+    $class = $this->classes ? $this->classes[0] : null;
+    $this->assertSame(
+      'FredEmmott\\DefinitionFinder\\Test\\ClassWithProperties',
+      $class?->getName(),
+    );
+    $this->assertEquals(
+      Vector { 'foo', 'bar', 'herp' },
+      $class?->getProperties()?->map($x ==> $x->getName()),
+    );
+    $class = $this->classes ? $this->classes[1] : null;
+    $this->assertSame(
+      'FredEmmott\\DefinitionFinder\\Test2\\ClassWithProperties',
+      $class?->getName()
+    );
+    $this->assertEquals(
+      Vector { 'foobar' },
+      $class?->getProperties()?->map($x ==> $x->getName()),
+    );
+  }
+
+  public function testPropertyVisibility(): void {
+    $class = $this->classes ? $this->classes[0] : null;
+    $this->assertSame(
+      'FredEmmott\\DefinitionFinder\\Test\\ClassWithProperties',
+      $class?->getName(),
+    );
+    $this->assertEquals(
+      Vector { false, false, true },
+      $class?->getProperties()?->map($x ==> $x->isPublic()),
+      'isPublic'
+    );
+    $this->assertEquals(
+      Vector { false, true, false },
+      $class?->getProperties()?->map($x ==> $x->isProtected()),
+      'isProtected'
+    );
+    $this->assertEquals(
+      Vector { true, false, false },
+      $class?->getProperties()?->map($x ==> $x->isPrivate()),
+      'isPrivate'
+    );
+    $class = $this->classes ? $this->classes[1] : null;
+    $this->assertSame(
+      'FredEmmott\\DefinitionFinder\\Test2\\ClassWithProperties',
+      $class?->getName()
+    );
+    $this->assertEquals(
+      Vector { true },
+      $class?->getProperties()?->map($x ==> $x->isPublic()),
+      'isPublic'
+    );
+  }
+
+  public function testPropertyTypes(): void {
+    $class = $this->classes ? $this->classes[0] : null;
+    $this->assertSame(
+      'FredEmmott\\DefinitionFinder\\Test\\ClassWithProperties',
+      $class?->getName(),
+    );
+    $this->assertEquals(
+      Vector { 'bool', 'int', 'string' },
+      $class?->getProperties()?->map(
+        $x ==> $x->getTypehint()?->getTypeName()
+      ),
+    );
+    $class = $this->classes ? $this->classes[1] : null;
+    $this->assertSame(
+      'FredEmmott\\DefinitionFinder\\Test2\\ClassWithProperties',
+      $class?->getName()
+    );
+    $this->assertEquals(
+      Vector { 'bool' },
+      $class?->getProperties()?->map($x ==> $x->getTypehint()?->getTypeName()),
+    );
+  }
+}

--- a/tests/data/class_contents.php
+++ b/tests/data/class_contents.php
@@ -8,6 +8,8 @@ class ClassWithContents {
 
   /** FooDoc */
   const string FOO = 'bar';
+  /** BarDoc */
+  const int BAR = 60 * 60 * 24;
 
   public function publicMethod(): void {}
   protected function protectedMethod(): void {}

--- a/tests/data/class_properties.php
+++ b/tests/data/class_properties.php
@@ -1,0 +1,22 @@
+<?hh // strict
+
+namespace FredEmmott\DefinitionFinder\Test;
+
+class ClassWithProperties {
+  private bool $foo = true;
+  protected int $bar = 123;
+  public string $herp = 'derp';
+
+  public function varsArentProps(): void {
+    $local = 'test';
+  }
+}
+
+namespace FredEmmott\DefinitionFinder\Test2 {
+  class ClassWithProperties {
+    public bool $foobar = false;
+    public function varsStillArentProps(): void {
+      $local = true;
+    }
+  }
+}

--- a/tests/data/php_class_contents.php
+++ b/tests/data/php_class_contents.php
@@ -7,6 +7,8 @@ class Foo {
 
   /** FooDoc */
   const FOO = 'bar';
+  /** BarDoc */
+  const BAR = 60 * 60 * 24;
 
   private $untypedProperty;
 }


### PR DESCRIPTION
This pull request handles issues with property and constant parsing.

Resolves issue #21 
Resolves issue #22 

Also adds support for the `T_VEC` symbol in `TypehintConsumer`, which fixes a failing unit test in `SelfTest`.