### PR TITLE
Add parsing of type constants.

### DIFF
--- a/src/builders/ScannedClassBuilder.php
+++ b/src/builders/ScannedClassBuilder.php
@@ -86,6 +86,7 @@ final class ScannedClassBuilder extends ScannedBaseBuilder {
       $methods,
       $properties,
       $scope->getConstants(),
+      $scope->getTypeConstants(),
       $this->generics,
       $this->parent,
       $this->interfaces,

--- a/src/builders/ScannedScopeBuilder.php
+++ b/src/builders/ScannedScopeBuilder.php
@@ -12,6 +12,7 @@ class ScannedScopeBuilder extends ScannedSingleTypeBuilder<ScannedScope> {
   private Vector<ScannedMethodBuilder> $methodBuilders = Vector { };
   private Vector<ScannedPropertyBuilder> $propertyBuilders = Vector { };
   private Vector<ScannedConstantBuilder> $constantBuilders = Vector { };
+  private Vector<ScannedTypeConstantBuilder> $typeConstantBuilders = Vector { };
   private Vector<ScannedEnumBuilder> $enumBuilders = Vector { };
   private Vector<ScannedTypeBuilder> $typeBuilders = Vector { };
   private Vector<ScannedNewtypeBuilder> $newtypeBuilders = Vector { };
@@ -37,6 +38,10 @@ class ScannedScopeBuilder extends ScannedSingleTypeBuilder<ScannedScope> {
 
   public function addConstant(ScannedConstantBuilder $b): void {
     $this->constantBuilders[] = $b;
+  }
+
+  public function addTypeConstant(ScannedTypeConstantBuilder $b): void {
+    $this->typeConstantBuilders[] = $b;
   }
 
   public function addEnum(ScannedEnumBuilder $b): void {
@@ -85,6 +90,7 @@ class ScannedScopeBuilder extends ScannedSingleTypeBuilder<ScannedScope> {
     $methods = $this->buildAll($this->methodBuilders);
     $properties = $this->buildAll($this->propertyBuilders);
     $constants = $this->buildAll($this->constantBuilders);
+    $typeConstants = $this->buildAll($this->typeConstantBuilders);
     $enums = $this->buildAll($this->enumBuilders);
     $types = $this->buildAll($this->typeBuilders);
     $newtypes = $this->buildAll($this->newtypeBuilders);
@@ -100,6 +106,7 @@ class ScannedScopeBuilder extends ScannedSingleTypeBuilder<ScannedScope> {
       $methods->addAll($scope->getMethods());
       $properties->addAll($scope->getProperties());
       $constants->addAll($scope->getConstants());
+      $typeConstants->addAll($scope->getTypeConstants());
       $enums->addAll($scope->getEnums());
       $types->addAll($scope->getTypes());
       $newtypes->addAll($scope->getNewtypes());
@@ -114,6 +121,7 @@ class ScannedScopeBuilder extends ScannedSingleTypeBuilder<ScannedScope> {
       $methods,
       $properties,
       $constants,
+      $typeConstants,
       $enums,
       $types,
       $newtypes,

--- a/src/builders/ScannedTypeConstantBuilder.php
+++ b/src/builders/ScannedTypeConstantBuilder.php
@@ -1,0 +1,23 @@
+<?hh // strict
+
+namespace FredEmmott\DefinitionFinder;
+
+class ScannedTypeConstantBuilder extends ScannedSingleTypeBuilder<ScannedTypeConstant> {
+  public function __construct(
+    string $name,
+    private ?ScannedTypehint $value,
+    private bool $isAbstract,
+  ) {
+    parent::__construct($name);
+  }
+
+  public function build(): ScannedTypeConstant {
+    return new ScannedTypeConstant(
+      nullthrows($this->position),
+      nullthrows($this->namespace).$this->name,
+      $this->docblock,
+      $this->value,
+      $this->isAbstract,
+    );
+  }
+}

--- a/src/consumers/TypeConstantConsumer.php
+++ b/src/consumers/TypeConstantConsumer.php
@@ -1,0 +1,77 @@
+<?hh // strict
+
+namespace FredEmmott\DefinitionFinder;
+
+/** Deals with type constants.
+ *
+ * abstract const type CONST_NAME [as ...];
+ * const type CONST_NAME = type_name;
+ *
+ * expects the next token in the queue to be DefinitionType::TYPE_DEF
+ */
+final class TypeConstantConsumer extends Consumer {
+
+  public function __construct(
+    TokenQueue $tq,
+    \ConstMap<string, string> $aliases,
+    private bool $isAbstract,
+  ) {
+    parent::__construct($tq, $aliases);
+  }
+
+  public function getBuilder(): ScannedTypeConstantBuilder {
+    $this->checkForTypeToken();
+    return new ScannedTypeConstantBuilder(
+      $this->extractName(),
+      $this->extractValue(),
+      $this->isAbstract,
+    );
+  }
+
+  private function checkForTypeToken(): void {
+    $this->consumeWhitespace();
+    list($next, $next_token) = $this->tq->shift();
+    invariant(
+      $next_token === DefinitionType::TYPE_DEF,
+      'misidentified type constant.',
+   );
+  }
+
+  private function extractName(): string {
+    $this->consumeWhitespace();
+    list($next, $next_type) = $this->tq->shift();
+    invariant(
+      StringishTokens::isValid($next_type),
+      'invalid type constant name %s',
+      $next,
+    );
+    return $next;
+  }
+
+  private function extractValue(): ?ScannedTypehint {
+    $this->consumeWhitespace();
+
+    $expectValue = false;
+
+    list($next, $next_type) = $this->tq->peek();
+    if($next === RelationshipToken::SUBTYPE) {
+      invariant(
+        $this->isAbstract,
+        'concrete type constant may not have a type constraint',
+      );
+      $this->tq->shift();
+      $this->consumeWhitespace();
+      return (new TypehintConsumer($this->tq, $this->aliases))->getTypehint();
+    }
+
+    if($next === '=') {
+      invariant(!$this->isAbstract, 'abstract type constants may not have concrete values');
+      $this->tq->shift();
+      $this->consumeWhitespace();
+      return (new TypehintConsumer($this->tq, $this->aliases))->getTypehint();
+    }
+
+      $this->consumeStatement();
+      return null;
+  }
+}

--- a/src/consumers/TypehintConsumer.php
+++ b/src/consumers/TypehintConsumer.php
@@ -111,6 +111,15 @@ final class TypehintConsumer extends Consumer {
       // Handle \foo\bar and foo\bar
       while ($this->tq->haveTokens()) {
         list($_, $ttype) = $this->tq->peek();
+        
+        // Handle \foo\bar::TYPE
+        if ($ttype === T_DOUBLE_COLON) {
+          list($tDoubleColon, $_) = $this->tq->shift();
+          list($tConstant, $_) = $this->tq->shift();
+          $type = $type . $tDoubleColon . $tConstant;
+          break;
+        }
+
         if ($ttype !== T_NS_SEPARATOR) {
           break;
         }

--- a/src/definitions/ScannedClass.php
+++ b/src/definitions/ScannedClass.php
@@ -15,6 +15,7 @@ abstract class ScannedClass
     private \ConstVector<ScannedMethod> $methods,
     private \ConstVector<ScannedProperty> $properties,
     private \ConstVector<ScannedConstant> $constants,
+    private \ConstVector<ScannedTypeConstant> $typeConstants,
     private \ConstVector<ScannedGeneric> $generics,
     private ?ScannedTypehint $parent,
     private \ConstVector<ScannedTypehint> $interfaces,
@@ -40,6 +41,10 @@ abstract class ScannedClass
 
   public function getConstants(): \ConstVector<ScannedConstant> {
     return $this->constants;
+  }
+
+  public function getTypeConstants(): \ConstVector<ScannedTypeConstant> {
+    return $this->typeConstants;
   }
 
   public function getGenericTypes(): \ConstVector<ScannedGeneric> {

--- a/src/definitions/ScannedScope.php
+++ b/src/definitions/ScannedScope.php
@@ -13,6 +13,7 @@ class ScannedScope extends ScannedBase {
     private \ConstVector<ScannedMethod> $methods,
     private \ConstVector<ScannedProperty> $properties,
     private \ConstVector<ScannedConstant> $constants,
+    private \ConstVector<ScannedTypeConstant> $typeConstants,
     private \ConstVector<ScannedEnum> $enums,
     private \ConstVector<ScannedType> $types,
     private \ConstVector<ScannedNewtype> $newtypes,
@@ -55,6 +56,10 @@ class ScannedScope extends ScannedBase {
 
   public function getConstants(): \ConstVector<ScannedConstant> {
     return $this->constants;
+  }
+
+  public function getTypeConstants(): \ConstVector<ScannedTypeConstant> {
+    return $this->typeConstants;
   }
 
   public function getEnums(): \ConstVector<ScannedEnum> {

--- a/src/definitions/ScannedTypeConstant.php
+++ b/src/definitions/ScannedTypeConstant.php
@@ -1,0 +1,32 @@
+<?hh // strict
+
+namespace FredEmmott\DefinitionFinder;
+
+class ScannedTypeConstant extends ScannedBase {
+  public function __construct(
+    SourcePosition $position,
+    string $name,
+    ?string $docblock,
+    private ?ScannedTypehint $value,
+    private bool $isAbstract,
+  ) {
+    parent::__construct(
+      $position,
+      $name,
+      /* attributes = */ Map { },
+      $docblock,
+    );
+  }
+
+  public static function getType(): DefinitionType {
+    return DefinitionType::CONST_DEF;
+  }
+
+  public function isAbstract(): bool {
+    return $this->isAbstract;
+  }
+
+  public function getValue(): ?ScannedTypehint {
+    return $this->value;
+  }
+}


### PR DESCRIPTION
This adds support for type constants scoped to a class.

```php
abstract class FooAbstract {
  abstract type BAR;
  public function (this::BAR $data): void {}
}

class Foo extends FooAbstract {
  const type BAR = int;
}
```

Looks like there may be a merge conflict in the scope consumer class with #20 because we both added a check for `T_ABSTRACT`.

Fixes #15 

@fredemmott @doublecompile