### PR TITLE
ScannedClass now returns trait ScannedTypehint collection

### DIFF
--- a/src/definitions/ScannedClass.php
+++ b/src/definitions/ScannedClass.php
@@ -74,6 +74,10 @@ abstract class ScannedClass
     return $this->interfaces;
   }
 
+  public function getTraitInfo(): \ConstVector<ScannedTypehint> {
+    return $this->traits;
+  }
+
   public function isAbstract(): bool {
     return $this->abstractness === AbstractnessToken::IS_ABSTRACT;
   }

--- a/src/definitions/ScannedClass.php
+++ b/src/definitions/ScannedClass.php
@@ -74,8 +74,12 @@ abstract class ScannedClass
     return $this->interfaces;
   }
 
-  public function getTraitInfo(): \ConstVector<ScannedTypehint> {
-    return $this->traits;
+  public function getTraitGenerics(): \ConstMap<string,\ConstVector<ScannedTypehint>> {
+    $traits = Map{};
+    foreach ($this->traits as $trait) {
+      $traits[$trait->getTypeName()] = $trait->getGenericTypes();
+    }
+    return $traits;
   }
 
   public function isAbstract(): bool {

--- a/tests/RelationshipsTest.php
+++ b/tests/RelationshipsTest.php
@@ -131,4 +131,18 @@ class RelationshipsTest extends \PHPUnit_Framework_TestCase {
       $def->getTraitNames(),
     );
   }
+
+  public function testUsesGenericTrait(): void {
+    $data = '<?hh class Foo { use Herp<string>; }';
+    $def = FileParser::FromData($data)->getClass('Foo');
+    $traits = $def->getTraitInfo();
+    $this->assertCount(1, $traits);
+    $trait = $traits->firstValue();
+    $this->assertNotNull($trait);
+    $this->assertEquals( 'Herp', $trait?->getTypeName() );
+    $this->assertEquals(
+      Vector { 'string' },
+      $trait?->getGenericTypes()?->map($a ==> $a->getTypeText()),
+    );
+  }
 }

--- a/tests/RelationshipsTest.php
+++ b/tests/RelationshipsTest.php
@@ -135,14 +135,12 @@ class RelationshipsTest extends \PHPUnit_Framework_TestCase {
   public function testUsesGenericTrait(): void {
     $data = '<?hh class Foo { use Herp<string>; }';
     $def = FileParser::FromData($data)->getClass('Foo');
-    $traits = $def->getTraitInfo();
+    $traits = $def->getTraitGenerics();
     $this->assertCount(1, $traits);
-    $trait = $traits->firstValue();
-    $this->assertNotNull($trait);
-    $this->assertEquals( 'Herp', $trait?->getTypeName() );
+    $this->assertEquals( 'Herp', $traits->firstKey());
     $this->assertEquals(
       Vector { 'string' },
-      $trait?->getGenericTypes()?->map($a ==> $a->getTypeText()),
+      $traits->firstValue()?->map($a ==> $a->getTypeText()),
     );
   }
 }


### PR DESCRIPTION
This PR includes the addition of a missing `getTraitInfo` method to the `ScannedClass`. (Plus an added test to check used trait generics).