### PR TITLE
Change consumeNonCode to a straight while loop.

### DIFF
--- a/src/consumers/ScopeConsumer.php
+++ b/src/consumers/ScopeConsumer.php
@@ -463,9 +463,10 @@ final class ScopeConsumer extends Consumer {
 
   /** ?> ... <?php */
   private function consumeNonCode(): void {
-    do {
+    $ttype = T_CLOSE_TAG;
+    while ($this->tq->haveTokens() && $ttype !== T_OPEN_TAG) {
       list ($_, $ttype) = $this->tq->shift();
-    } while ($this->tq->haveTokens() && $ttype !== T_OPEN_TAG);
+    }
   }
 
   private function consumeUseStatement(): ImmMap<string, string> {

--- a/tests/EndClosingTagTest.php
+++ b/tests/EndClosingTagTest.php
@@ -1,0 +1,11 @@
+<?hh // strict
+
+class EndClosingTagTest extends AbstractPHPTest {
+  protected function getFilename(): string {
+    return 'end_closing_tag.php';
+  }
+
+  protected function getPrefix(): string {
+    return '';
+  }
+}

--- a/tests/data/end_closing_tag.php
+++ b/tests/data/end_closing_tag.php
@@ -1,0 +1,17 @@
+<?php
+
+class SimpleClass {
+}
+
+abstract class SimpleAbstractClass {
+}
+
+final class SimpleFinalClass {
+}
+
+interface SimpleInterface {
+}
+
+trait SimpleTrait {
+}
+?>


### PR DESCRIPTION
This handles cases where a closing PHP tag isn't followed by any tokens.
Fixes #39