### PR TITLE
Extend syntax support

### DIFF
--- a/src/consumers/UserAttributesConsumer.php
+++ b/src/consumers/UserAttributesConsumer.php
@@ -62,6 +62,14 @@ final class UserAttributesConsumer extends Consumer {
           $this->tq->getLine(),
         );
         $this->consumeWhitespace();
+
+        // Handle trailing commas
+        list ($t, $ttype) = $this->tq->shift();
+        if ($t === ')') {
+          break;
+        }
+
+        $this->tq->unshift($t, $ttype);
       }
 
       $this->consumeWhitespace();

--- a/src/expression/StaticArrayExpression.php
+++ b/src/expression/StaticArrayExpression.php
@@ -29,6 +29,7 @@ final class StaticArrayExpression extends Expression {
     if ($t !== $end) {
       return null;
     }
+    self::consumeWhitespace($tq);
     return new self($values);
   }
 }

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -51,6 +51,14 @@ class AttributesTest extends \PHPUnit_Framework_TestCase {
     );
   }
 
+  public function testWithFormattedArrayAttribute(): void {
+    $class = $this->findClass('ClassWithFormattedArrayAttribute');
+    $this->assertEquals(
+      Map { 'Bar' => Vector {['herp']} },
+      $class->getAttributes(),
+    );
+  }
+
   public function testWithSingleIntAttribute(): void {
     $class = $this->findClass('ClassWithIntAttribute');
     $this->assertEquals(

--- a/tests/data/attributes.php
+++ b/tests/data/attributes.php
@@ -32,3 +32,10 @@ Bar
 )
 >>
 class ClassWithFormattedAttributes {}
+
+<<
+Bar(
+  ['herp']
+)
+>>
+class ClassWithFormattedArrayAttribute {}

--- a/tests/data/attributes.php
+++ b/tests/data/attributes.php
@@ -28,7 +28,7 @@ Foo,
 Bar
 (
     'herp',
-    'derp'
+    'derp',
 )
 >>
 class ClassWithFormattedAttributes {}


### PR DESCRIPTION
This adds in support for trailing commas in attribute lists and for whitespace after a closing array. Both are inserted by `hh_format` and are valid at runtime and in the typechecker.